### PR TITLE
Redefine portability criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ wasi-i2c is currently in [Phase 1](https://github.com/WebAssembly/WASI/blob/main
 
 ### Portability Criteria
 
-WASI-I2C must have at least an independent implementation for the following platforms: Linux, ARM, RISC-V and a RTOS (Zephyr or FreeRTOS). Furthermore, an implementation also needs to be provided for a microcontroller. Here, a Cortex-M4 is targeted as the lowerbound.
+WASI-I2C must have at least an independent implementation for the following platforms: 
+- Linux (ARM)
+- Linux (RISC-V)
+- RTOS (Zephyr or FreeRTOS)
+- Microcontroller implementation (Cortex M4 as a lowerbound)
 
 ### Introduction
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ wasi-i2c is currently in [Phase 1](https://github.com/WebAssembly/WASI/blob/main
 
 ### Portability Criteria
 
-WASI-I2C must have at least an independent implementation for the following platforms: Linux, ARM and RISC-V. Furthermore, an implementation also needs to be provided for a microcontroller. Here, a Cortex-M4 is targeted as the lowerbound.
+WASI-I2C must have at least an independent implementation for the following platforms: Linux, ARM, RISC-V and a RTOS (Zephyr or FreeRTOS). Furthermore, an implementation also needs to be provided for a microcontroller. Here, a Cortex-M4 is targeted as the lowerbound.
 
 ### Introduction
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ wasi-i2c is currently in [Phase 1](https://github.com/WebAssembly/WASI/blob/main
 
 ### Portability Criteria
 
-WASI-I2C must have at least two complete independent implementations. One implementation must be implemented on a microcontroller.
+WASI-I2C must have at least an independent implementation for the following platforms: Linux, ARM and RISC-V. Furthermore, an implementation also needs to be provided for a microcontroller. Here, a Cortex-M4 is targeted as the lowerbound.
 
 ### Introduction
 


### PR DESCRIPTION
In the WebAssembly CG WASI Subgroup meeting of 4 April, it was concluded that the definition of *a microcontroller* was too vague. The aim of this PR is to solve this vagueness.

The original idea was to do a GitHub discussions, but after meeting with the other champions, we felt pretty confident with our redefined criteria.

