### PR TITLE
Clarify HAL usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ WASI-I2C must have at least an independent implementation for the following plat
 
 ### Introduction
 
-The WASI-I2C proposal defines an API for the I2C protocol. The API of [embedded_hal](https://github.com/rust-embedded/embedded-hal) is closely followed.
+The WASI-I2C proposal defines an API for the I2C protocol. The API of [embedded_hal](https://github.com/rust-embedded/embedded-hal) is taken as an inspiration, but it is not necessary to make use of this library to implement this proposal.
 
 Reference implementations can be found in [i2c-wasm-components](https://github.com/Zelzahn/i2c-wasm-components). Furthermore, there is also a [wasi-embedded-hal](https://crates.io/crates/wasi-embedded-hal) crate that implements the `embedded-hal` traits for the generated bindings.
 
@@ -33,6 +33,8 @@ The primary goal is to provide an interface that WASI programs can use to read a
 ### Non-goals
 
 Although I2C is in some aspects not that different from SPI, the purpose of this proposal is to solely focus on I2C.
+
+Currently, behaviour that is not specified by this API is seen as undefined and, unless there's sufficient interest, is regarded as out-of-scope.
 
 ### API walk-through
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ wasi-i2c is currently in [Phase 1](https://github.com/WebAssembly/WASI/blob/main
 
 ### Portability Criteria
 
-WASI-I2C must have at least an independent implementation for the following platforms: Linux, ARM, RISC-V and a RTOS (Zephyr or FreeRTOS). Furthermore, an implementation also needs to be provided for a microcontroller. Here, a Cortex-M4 is targeted as the lowerbound.
+WASI-I2C must have at least an independent implementation for the following platforms: 
+- Linux (ARM)
+- Linux (RISC-V)
+- RTOS (Zephyr or FreeRTOS)
+- Microcontroller implementation (Cortex M4 as a lowerbound)
 
 ### Introduction
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ wasi-i2c is currently in [Phase 1](https://github.com/WebAssembly/WASI/blob/main
 
 ### Portability Criteria
 
-WASI-I2C must have at least an independent implementation for the following platforms: Linux, ARM and RISC-V. Furthermore, an implementation also needs to be provided for a microcontroller. Here, a Cortex-M4 is targeted as the lowerbound.
+WASI-I2C must have at least an independent implementation for the following platforms: Linux, ARM, RISC-V and a RTOS (Zephyr or FreeRTOS). Furthermore, an implementation also needs to be provided for a microcontroller. Here, a Cortex-M4 is targeted as the lowerbound.
 
 ### Introduction
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ wasi-i2c is currently in [Phase 1](https://github.com/WebAssembly/WASI/blob/main
 
 ### Portability Criteria
 
-WASI-I2C must have at least two complete independent implementations. One implementation must be implemented on a microcontroller.
+WASI-I2C must have at least an independent implementation for the following platforms: Linux, ARM and RISC-V. Furthermore, an implementation also needs to be provided for a microcontroller. Here, a Cortex-M4 is targeted as the lowerbound.
 
 ### Introduction
 


### PR DESCRIPTION
Currently, the wording around `embedded-hal` can be interpreted as such that this library is necessary for an implementation. This is not the case, and thus this phrase is rewritten.

In the non-goals, a paragraph is added around behaviour not specified in this proposal. The intent behind this paragraph is to only populate the specification with behaviour with clear interest from the industry.
