### PR TITLE
Add reference hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WASI-I2C must have at least an independent implementation for the following plat
 | Platform | Architecture | Reference Hardware |
 | ------------- | ------------- | ------------- |
 | Linux  | ARM  | Raspberry Pi 3 Model B |
-| Linux  | RISC-V  | ESP32 |
+| RTOS (Zephyr or FreeRTOS)  | RISC-V  | ESP32 |
 | RTOS (Zephyr or FreeRTOS) | ARM32 | Nucleo F412ZG |
 
 Furthermore, implementations shouldn't take up all the available RAM.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ WASI-I2C must have an implementation for at least the following platforms:
 | Platform                  | Architecture  | Reference Hardware     |
 | ------------------------- | ------------- | ---------------------- |
 | Linux                     | ARM           | Raspberry Pi 3 Model B |
-| Linux                     | RISC-V        | ESP32-C3               |
+| RTOS (NuttX or Zephyr)    | RISC-V        | ESP32-C3               |
 | RTOS (Zephyr or FreeRTOS) | ARM32         | Nucleo F412ZG          |
 
 Furthermore, the interface should be designed in such a way to use as little memory as reasonably possible, to ensure enough RAM on these boards is still available for the applications.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ wasi-i2c is currently in [Phase 1](https://github.com/WebAssembly/WASI/blob/main
 ### Portability Criteria
 
 WASI-I2C must have at least an independent implementation for the following platforms: 
-- Linux (ARM)
-- Linux (RISC-V)
-- RTOS (Zephyr or FreeRTOS)
-- Microcontroller implementation (Cortex M4 as a lowerbound)
+| Platform | Architecture | Reference Hardware |
+| ------------- | ------------- | ------------- |
+| Linux  | ARM  | Raspberry Pi 3 Model B |
+| Linux  | RISC-V  | ESP32 |
+| RTOS (Zephyr or FreeRTOS) | ARM32 | Nucleo F412ZG &
+
+Furthermore, implementations shouldn't take up all the available RAM.
 
 ### Introduction
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ WASI-I2C must have at least an independent implementation for the following plat
 | ------------- | ------------- | ------------- |
 | Linux  | ARM  | Raspberry Pi 3 Model B |
 | Linux  | RISC-V  | ESP32 |
-| RTOS (Zephyr or FreeRTOS) | ARM32 | Nucleo F412ZG &
+| RTOS (Zephyr or FreeRTOS) | ARM32 | Nucleo F412ZG |
 
 Furthermore, implementations shouldn't take up all the available RAM.
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ wasi-i2c is currently in [Phase 1](https://github.com/WebAssembly/WASI/blob/main
 
 ### Portability Criteria
 
-WASI-I2C must have at least an independent implementation for the following platforms: 
-| Platform | Architecture | Reference Hardware |
-| ------------- | ------------- | ------------- |
-| Linux  | ARM  | Raspberry Pi 3 Model B |
-| RTOS (Zephyr or FreeRTOS)  | RISC-V  | ESP32 |
-| RTOS (Zephyr or FreeRTOS) | ARM32 | Nucleo F412ZG |
+WASI-I2C must have an implementation for at least the following platforms:
 
-Furthermore, implementations shouldn't take up all the available RAM.
+| Platform                  | Architecture  | Reference Hardware     |
+| ------------------------- | ------------- | ---------------------- |
+| Linux                     | ARM           | Raspberry Pi 3 Model B |
+| Linux                     | RISC-V        | ESP32-C3               |
+| RTOS (Zephyr or FreeRTOS) | ARM32         | Nucleo F412ZG          |
+
+Furthermore, the interface should be designed in such a way to use as little memory as reasonably possible, to ensure enough RAM on these boards is still available for the applications.
 
 ### Introduction
 


### PR DESCRIPTION
The aim of this reference hardware is to further define the exact capabilities we're targeting with each platform + architecture combination.