### PR TITLE
Update readme to move to phase 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A proposed [WebAssembly System Interface](https://github.com/WebAssembly/WASI) A
 
 ### Current Phase
 
-wasi-i2c is currently in [Phase 1](https://github.com/WebAssembly/WASI/blob/main/Proposals.md#phase-1---feature-proposal-cg)
+wasi-i2c is currently in [Phase 2](https://github.com/WebAssembly/WASI/blob/main/Proposals.md#phase-2---proposed-spec-text-available-cg--wg)
 
 ### Champions
 


### PR DESCRIPTION
We noticed that the proposal's readme wasn't updated after moving to phase 2 as [discussed during the WASI SG meeting of May 16 2024](https://github.com/WebAssembly/meetings/blob/main/wasi/2024/WASI-05-16.md). This small PR fixes that.