### PR TITLE
Update link to WASI Proposals.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A proposed [WebAssembly System Interface](https://github.com/WebAssembly/WASI) A
 
 ### Current Phase
 
-wasi-i2c is currently in [Phase 2](https://github.com/WebAssembly/WASI/blob/main/Proposals.md#phase-2---proposed-spec-text-available-cg--wg)
+wasi-i2c is currently in [Phase 2](https://github.com/WebAssembly/WASI/blob/main/docs/Proposals.md#phase-2---proposed-spec-text-available-cg--wg)
 
 ### Champions
 


### PR DESCRIPTION
The location of the WASI Proposals.md file is being changed in https://github.com/WebAssembly/WASI/pull/831, this updates all the links in this repository to reflect that change. I'm initially filing this PR as a draft. I'll mark it as ready to review once the linked PR has been merged. Thanks!